### PR TITLE
fix: handle caption truncation with empty desc and long tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "mongoose": "^8.9.5",
         "pino": "^8.7.0",
         "pino-pretty": "^9.1.1",
-        "sharp": "^0.34.3",
+        "sharp": "^0.34.5",
         "telegraf": "^4.16.3",
         "tough-cookie": "^4.1.3",
         "ts-node": "^10.4.0",

--- a/src/utils/caption.ts
+++ b/src/utils/caption.ts
@@ -137,15 +137,18 @@ export function infoCmdCaption(artwork_info: ArtworkInfo) {
     }
 
     // When the caption length is longer than 1024, cut off the description
-    while (caption.length > MAX_CAPTION_LENGTH && artwork_info.raw_tags && artwork_info.raw_tags.length > 0) {
-        artwork_info.raw_tags.pop();
-        caption = infoCmdCaption(artwork_info);
-    }
     if (caption.length > MAX_CAPTION_LENGTH && artwork_info.desc) {
         artwork_info.desc = cutDescription(
             escapeHtmlTags(artwork_info.desc),
             caption.length
         );
+        caption = infoCmdCaption(artwork_info);
+    }
+    while (
+        caption.length > MAX_CAPTION_LENGTH &&
+        artwork_info.raw_tags?.length > 0
+    ) {
+        artwork_info.raw_tags.pop();
         caption = infoCmdCaption(artwork_info);
     }
 

--- a/src/utils/caption.ts
+++ b/src/utils/caption.ts
@@ -137,7 +137,11 @@ export function infoCmdCaption(artwork_info: ArtworkInfo) {
     }
 
     // When the caption length is longer than 1024, cut off the description
-    if (caption.length > MAX_CAPTION_LENGTH) {
+    while (caption.length > MAX_CAPTION_LENGTH && artwork_info.raw_tags && artwork_info.raw_tags.length > 0) {
+        artwork_info.raw_tags.pop();
+        caption = infoCmdCaption(artwork_info);
+    }
+    if (caption.length > MAX_CAPTION_LENGTH && artwork_info.desc) {
         artwork_info.desc = cutDescription(
             escapeHtmlTags(artwork_info.desc),
             caption.length


### PR DESCRIPTION
Fixed an issue where empty `artwork_info.desc` caused truncation errors, and `artwork_info.raw_tags` resulted in an excessively long caption.